### PR TITLE
Update ordnance-survey.yaml

### DIFF
--- a/datasets/Geospatial/ordnance-survey.yaml
+++ b/datasets/Geospatial/ordnance-survey.yaml
@@ -1,7 +1,7 @@
 name: Ordnance Survey Data Hub
 description: Great Britain’s Geospatial Data platform.
 source_url: https://osdatahub.os.uk/
-open_data: true
+open_data: false
 made_by_ukgov: true
 topic: Geospatial
 subtopics:
@@ -15,7 +15,7 @@ subtopics:
 format: API/ESRI Shapefile/MapInfo/+more
 is_active: true
 update_frequency: Varied
-licence: Open Governmet Licence
+licence: Various
 coverage:
   spatial: United Kingdom
 tags:

--- a/datasets/Law/caselaw.yaml
+++ b/datasets/Law/caselaw.yaml
@@ -11,7 +11,7 @@ subtopics:
 format: XML
 is_active: true
 update_frequency: Weekly
-licence: Open Government Licence v3.0
+licence: Open Justice Licence
 coverage:
   temporal:
     start: "1865-01-01"


### PR DESCRIPTION
The OS Data Hub contains a mix of open data and data under various more restrictive licences that require payment. Due to the Public Sector Geospatial Agreement whether or not the data user is part of the public sector may affect licensing availability. (There are various other exceptions to the licences but that gets even deeper into the data weeds).

As a result suggest changing open_date to false and changing licence to "Various"